### PR TITLE
Add option to collapse blocks by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ tabs:
 
 1. **Hide block icons**. This is helpful if you are using our [Kirby Visual Block Selector](https://github.com/junohamburg/kirby-visual-block-selector).
 2. **Disable equal height tabs**. By default, the largest tab sets the overall height, so there are no jumps when switching between tabs.
+3. **Collapse blocks by default**. Useful to declutter the panel if a high number of blocks is present.
 
 **site/config/config.php**
 
@@ -61,6 +62,7 @@ return [
   'junohamburg.block-preview-fields' => [
     'icon' => false, // default: true
     'equalHeightTabs' => false // default: true
+    'collapsedByDefault' => true // default: false
   ],
 ];
 ```

--- a/index.js
+++ b/index.js
@@ -41,16 +41,30 @@ panel.plugin('junohamburg/block-preview-fields', {
   blocks: {
     fields: {
       data() {
-        const options = this.$store.getters.getOptions
-        const collapsedByDefault = options.collapsedByDefault
+        const options = this.$store.getters.getOptions;
+        const collapsedByDefault = options.collapsedByDefault;
+        var isHidden = collapsedByDefault;
         const storageValue = sessionStorage.getItem(
           `kirby.blockPreviewFields.${this.$attrs.endpoints.field}.${this.$attrs.id}`
         );
 
-        // if option collapsedByDefault is set use its value otherwise default to session storage
+        // if the storage value is null the block just got created and shouldn't be hidden
+        if(storageValue === null) {
+          isHidden = false
+
+          // saving the item's state will make sure that the item isn't interpreted as a new block on next load
+          sessionStorage.setItem(
+            `kirby.blockPreviewFields.${this.$attrs.endpoints.field}.${this.$attrs.id}`,
+            isHidden
+          );
+        } else {
+          // all other blocks get controlled by the config value
+          isHidden = collapsedByDefault
+        }
+
         return {
           currentTab: Object.values(this.fieldset.tabs)[0].name,
-          isHidden: storageValue ? JSON.parse(storageValue) : collapsedByDefault
+          isHidden: isHidden
         };
       },
       computed: {

--- a/index.js
+++ b/index.js
@@ -20,6 +20,11 @@ panel.plugin('junohamburg/block-preview-fields', {
           updateOptions({ commit }, { options }) {
             commit('updateOptions', options);
           }
+        },
+        getters: {
+          getOptions(options) {
+            return options.options
+          }
         }
       });
 
@@ -36,13 +41,16 @@ panel.plugin('junohamburg/block-preview-fields', {
   blocks: {
     fields: {
       data() {
+        const options = this.$store.getters.getOptions
+        const collapsedByDefault = options.collapsedByDefault
+        const storageValue = sessionStorage.getItem(
+          `kirby.blockPreviewFields.${this.$attrs.endpoints.field}.${this.$attrs.id}`
+        );
+
+        // if option collapsedByDefault is set use its value otherwise default to session storage
         return {
           currentTab: Object.values(this.fieldset.tabs)[0].name,
-          isHidden: JSON.parse(
-            sessionStorage.getItem(
-              `kirby.blockPreviewFields.${this.$attrs.endpoints.field}.${this.$attrs.id}`
-            )
-          )
+          isHidden: storageValue ? JSON.parse(storageValue) : collapsedByDefault
         };
       },
       computed: {

--- a/index.php
+++ b/index.php
@@ -4,6 +4,7 @@ Kirby::plugin('junohamburg/block-preview-fields', [
   'options' => [
     'icon' => true,
     'equalHeightTabs' => true,
+    'collapedByDefault' => false, 
   ],
   'api' => [
     'routes' => [
@@ -13,7 +14,8 @@ Kirby::plugin('junohamburg/block-preview-fields', [
           // Get options for Vue component
           return [
             'icon' => kirby()->option('junohamburg.block-preview-fields.icon'),
-            'equalHeightTabs' => kirby()->option('junohamburg.block-preview-fields.equalHeightTabs')
+            'equalHeightTabs' => kirby()->option('junohamburg.block-preview-fields.equalHeightTabs'),
+            'collapsedByDefault' => kirby()->option('junohamburg.block-preview-fields.collapsedByDefault')
           ];
         }
       ]


### PR DESCRIPTION
First of all thanks for contributing this plugin to the kirby community. In my opinion it is the best of the current fields-preview plugins as being able to use tabs is great. Still in my opinion your plugin is missing an option to collapse all blocks by default. This could be useful when working with a high number of blocks as the view can get cluttered easily.

I've implemented this option non-invasively as the plugin works exactly the same as before this pull request by default. Please tell me if I am breaking any Vue coding standards as I usually don't work with Vue. I'm happy to update the code if needed. 